### PR TITLE
timeout

### DIFF
--- a/example/timeout.yml
+++ b/example/timeout.yml
@@ -1,0 +1,41 @@
+# in:
+#   type: random
+#   rows: 100
+#   schema:
+#     id: primary_key
+#     name: string
+#     score: integer
+in:
+  type: file
+  path_prefix: example/example.csv
+  parser:
+    type: csv
+    charset: UTF-8
+    newline: CRLF
+    null_string: 'NULL'
+    skip_header_lines: 1
+    comment_line_marker: '#'
+    columns:
+      - {name: timestamp_date, type: timestamp, format: "%Y-%m-%d", timezone: "+09:00"}
+      - {name: string_date,    type: string}
+      - {name: foo,   type: string}
+      - {name: bar,   type: string}
+      - {name: id,    type: long}
+      - {name: name,  type: string}
+      - {name: score, type: double} 
+out:
+  type: vertica 
+  host: 127.0.0.1
+  user: dbadmin
+  password: xxxxxxx
+  database: vdb
+  schema: sandbox
+  table: embulk_test
+  mode: drop_insert
+  copy_mode: DIRECT
+  abort_on_error: true
+  reject_on_materialized_type_error: true
+  default_timezone: 'Asia/Tokyo'
+  write_timeout: 660
+  dequeue_timeout: 780
+  finish_timeout: 180

--- a/lib/embulk/output/vertica.rb
+++ b/lib/embulk/output/vertica.rb
@@ -34,6 +34,9 @@ module Embulk
           'resource_pool'    => config.param('resource_pool',    :string,  :default => nil),
           'reject_on_materialized_type_error' => config.param('reject_on_materialized_type_error', :bool, :default => false),
           'pool'             => config.param('pool',             :integer, :default => processor_count),
+          'write_timeout'    => config.param('write_timeout',    :integer, :default => nil), # like 11 * 60 sec
+          'dequeue_timeout'  => config.param('dequeue_timeout',  :integer, :default => nil), # like 13 * 60 sec
+          'finish_timeout'   => config.param('finish_timeout',   :integer, :default => nil), # like 3 * 60 sec
         }
 
         @thread_pool_proc = Proc.new do


### PR DESCRIPTION
1. Add write_timeout
2. Add dequeue_timeout
3. Add finish_timeout
4. Fix outer_thread.raise failed on some errors
5. Get thread dump if unknown timeout occurs
6. Fix closing procedure for when jdbc driver is already closed
